### PR TITLE
[fix] Update prop-types to avoid failed prop types check

### DIFF
--- a/src/components/OSMMap/OSMMap.jsx
+++ b/src/components/OSMMap/OSMMap.jsx
@@ -72,10 +72,7 @@ const OSMMap = ({
 };
 
 OSMMap.propTypes = {
-  center: PropTypes.shape({
-    latitude: PropTypes.number,
-    longitude: PropTypes.number,
-  }),
+  center: PropTypes.arrayOf(PropTypes.number),
   markers: PropTypes.arrayOf(
     PropTypes.shape({
       latitude: PropTypes.number,


### PR DESCRIPTION
It's not ideal to say that ``center`` is an arrayOf(number), since it's actually a tuple-like object, but that's how it is at the moment, so I guess this is the best prop-type definition.