### PR TITLE
fix: resume copyright of OSM

### DIFF
--- a/locales/de/LC_MESSAGES/volto.po
+++ b/locales/de/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/en/LC_MESSAGES/volto.po
+++ b/locales/en/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/es/LC_MESSAGES/volto.po
+++ b/locales/es/LC_MESSAGES/volto.po
@@ -20,11 +20,6 @@ msgstr ""
 "X-Is-Fallback-For: es-ar es-bo es-cl es-co es-cr es-do es-ec es-es es-sv es-gt es-hn es-mx es-ni es-pa es-py es-pe es-pr es-us es-uy es-ve\n"
 "X-Generator: Poedit 2.2.1\n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr "&amp;copy los contribuyentes de <a href=\"http://osm.org/copyright\">OpenStreetMap</a>"
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -54,6 +49,26 @@ msgstr "Latitud"
 # defaultMessage: Longitude
 msgid "longitude"
 msgstr "Longitud"
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
+msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Search address on map

--- a/locales/eu/LC_MESSAGES/volto.po
+++ b/locales/eu/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/fr/LC_MESSAGES/volto.po
+++ b/locales/fr/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -45,6 +40,26 @@ msgstr "Latitudine"
 # defaultMessage: Longitude
 msgid "longitude"
 msgstr "Longitudine"
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr "Clicca per vedere i dettagli"
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr "Zoom avanti"
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr "Zoom indietro"
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
+msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Search address on map

--- a/locales/ja/LC_MESSAGES/volto.po
+++ b/locales/ja/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/nl/LC_MESSAGES/volto.po
+++ b/locales/nl/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/pt/LC_MESSAGES/volto.po
+++ b/locales/pt/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/pt_BR/LC_MESSAGES/volto.po
+++ b/locales/pt_BR/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/ro/LC_MESSAGES/volto.po
+++ b/locales/ro/LC_MESSAGES/volto.po
@@ -11,11 +11,6 @@ msgstr ""
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
-
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
 msgid "geolocation"
@@ -44,6 +39,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2023-05-17T18:30:58.151Z\n"
+"POT-Creation-Date: 2025-02-04T15:19:06.432Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -12,11 +12,6 @@ msgstr ""
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8\n"
 "Domain: volto\n"
-
-#: components/OSMMap/OSMMap
-# defaultMessage: &amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors
-msgid "&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors"
-msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Geolocation
@@ -46,6 +41,26 @@ msgstr ""
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget
 # defaultMessage: Longitude
 msgid "longitude"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Click to view details
+msgid "osmmap - pin click"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom in
+msgid "osmmap - zoom in"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: Zoom out
+msgid "osmmap - zoom out"
+msgstr ""
+
+#: components/OSMMap/OSMMap
+# defaultMessage: <span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>
+msgid "osmmap copyright contributors"
 msgstr ""
 
 #: components/Widgets/GeoLocationWidget/GeoLocationWidget

--- a/src/components/OSMMap/OSMMap.jsx
+++ b/src/components/OSMMap/OSMMap.jsx
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
 import { defineMessages, useIntl } from 'react-intl';
-import { Map, TileLayer, Marker, Tooltip, Popup } from 'react-leaflet';
+import {
+  Map,
+  TileLayer,
+  Marker,
+  Tooltip,
+  Popup,
+  ZoomControl,
+} from 'react-leaflet';
 import MarkerClusterGroup from 'volto-venue/components/OSMMap/MarkerClusterGroup';
 
 // eslint-disable-next-line import/no-unresolved
@@ -20,6 +27,18 @@ const messages = defineMessages({
     id: 'osmmap copyright contributors',
     defaultMessage:
       '<span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>',
+  },
+  pinClick: {
+    id: 'osmmap - pin click',
+    defaultMessage: 'Click to view details',
+  },
+  zoomIn: {
+    id: 'osmmap - zoom in',
+    defaultMessage: 'Zoom in',
+  },
+  zoomOut: {
+    id: 'osmmap - zoom out',
+    defaultMessage: 'Zoom out',
   },
 });
 
@@ -64,7 +83,7 @@ const OSMMap = ({
             }
           }}
           icon={position.divIcon ? L.divIcon(position.divIcon) : DefaultIcon}
-          aria-label={position.title}
+          alt={position.title + ' - ' + intl.formatMessage(messages.pinClick)}
         >
           {showTooltip && position.title && (
             <Tooltip
@@ -94,10 +113,16 @@ const OSMMap = ({
       <Map
         center={center ?? [markers[0].latitude, markers[0].longitude]}
         zoom={zoom}
+        zoomControl={false}
         id="geocoded-result"
         bounds={bounds}
         {...mapOptions}
       >
+        <ZoomControl
+          position="topleft"
+          zoomInTitle={intl.formatMessage(messages.zoomIn)}
+          zoomOutTitle={intl.formatMessage(messages.zoomOut)}
+        />
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution={intl.formatMessage(messages.attribution)}

--- a/src/components/OSMMap/OSMMap.jsx
+++ b/src/components/OSMMap/OSMMap.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import L from 'leaflet';
+import { defineMessages, useIntl } from 'react-intl';
 import { Map, TileLayer, Marker, Tooltip, Popup } from 'react-leaflet';
 import MarkerClusterGroup from 'volto-venue/components/OSMMap/MarkerClusterGroup';
 
@@ -13,6 +14,14 @@ import iconShadow from 'volto-venue/components/OSMMap/images/marker-shadow.png';
 import 'volto-venue/components/OSMMap/OSMMap.css';
 // eslint-disable-next-line import/no-unresolved
 import 'volto-venue/components/OSMMap/leaflet.css';
+
+const messages = defineMessages({
+  attribution: {
+    id: 'osmmap copyright contributors',
+    defaultMessage:
+      '<span class="attribution"><a href="http://osm.org/copyright">OpenStreetMap</a> &copy; contributors</span>',
+  },
+});
 
 let DefaultIcon = L.icon({
   iconUrl: icon,
@@ -35,6 +44,7 @@ const OSMMap = ({
   cluster = false,
   mapOptions = {},
 }) => {
+  const intl = useIntl();
   const bounds = L.latLngBounds(
     markers.map((marker) => [marker.latitude, marker.longitude]),
   );
@@ -88,7 +98,10 @@ const OSMMap = ({
         bounds={bounds}
         {...mapOptions}
       >
-        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <TileLayer
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution={intl.formatMessage(messages.attribution)}
+        />
         {cluster ? (
           <MarkerClusterGroup>{renderMarkers}</MarkerClusterGroup>
         ) : (

--- a/src/components/Widgets/GeoLocationWidget/GeoLocationWidget.css
+++ b/src/components/Widgets/GeoLocationWidget/GeoLocationWidget.css
@@ -62,3 +62,8 @@
 .geolocation-widget .geolocation-selected-wrapper button.ui.button {
   padding: 0.6rem;
 }
+
+.geolocation-widget .leaflet-control-zoom a,
+.geolocation-widget .leaflet-control-zoom a:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
Resumed copyright for OSM because required. 

If you don't want to show it, hide via css rules. It's wrapped with class .attribution


Fixed underline style for zoom buttons.

<img width="551" alt="Screenshot 2025-01-29 alle 14 02 01" src="https://github.com/user-attachments/assets/327a20f6-3acd-4bae-a666-614c7cb01ed5" />


Fixed a11y:

before was:

https://github.com/user-attachments/assets/3b965fe6-2ce0-466b-902b-2ed5d9b34014

now is like this, with italian translations also for zoom-in and zoom-out buttons:

https://github.com/user-attachments/assets/71886e79-110f-423d-8816-3c0b1ecede70


The resumed Copyright label doesn't  interfere with accessibility (keyboard navigation and screen reader), as can be seen from the video
